### PR TITLE
LibXML2 and LibXSLT are missing!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,8 @@ RUN apk --update --no-cache add \
     grep \
     gzip \
     libressl \
+    libxml2-dev \
+    libxslt-dev \
     libstdc++ \
     mediainfo \
     ncurses \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,6 @@ RUN apk --update --no-cache add \
     grep \
     gzip \
     libressl \
-    libxml2-dev \
-    libxslt-dev \
     libstdc++ \
     mediainfo \
     ncurses \
@@ -105,10 +103,11 @@ RUN apk --update --no-cache add \
     zlib \
   && apk --update --no-cache add -t build-dependencies \
     build-base \
-    expat-dev \
     git \
-    linux-headers \
     libressl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    linux-headers \
     pcre-dev \
     zlib-dev \
   && cd /usr/src \


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/12892508/50724583-52de3300-10f0-11e9-924b-ef839f9e49fc.png)

libxml2 and libxslt is missing and required to build the dockerimage.

So i added the libraries libxml2 and libxslt to build the nginx module.