### PR TITLE
Create torrent directory in rutorrent directory.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,6 +115,7 @@ mkdir -p ${PASSWD_PATH} \
   ${RUTORRENT_HOME}/plugins \
   ${RUTORRENT_HOME}/plugins-conf \
   ${RUTORRENT_HOME}/share/users \
+  ${RUTORRENT_HOME}/share/torrents \
   ${RUTORRENT_HOME}/themes \
   /run/rtorrent
 touch ${PASSWD_PATH}/rpc.htpasswd \


### PR DESCRIPTION
When running the container with an empty data directory the torrent directory was not being created. In that state no new torrents could be added via the ruTorrent UI.