### PR TITLE
Add start-period to HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,5 +220,5 @@ VOLUME [ "/data", "/passwd" ]
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/usr/bin/supervisord", "-c", "/etc/supervisord.conf" ]
 
-HEALTHCHECK --interval=10s --timeout=5s \
+HEALTHCHECK --interval=10s --timeout=5s --start-period=300s \
   CMD /usr/local/bin/healthcheck


### PR DESCRIPTION
Depending on the amount of data, the permission fixing can take a while.
After 30s the service enters unhealthy state. For that, the start-period is preferable.