### PR TITLE
Fix cloudflare plugin

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -181,11 +181,12 @@ cat > /var/www/rutorrent/conf/config.php <<EOL
 \$XMLRPCMountPoint = "/RPC2"; // DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
 \$pathToExternals = array(
-    "php"   => '',
-    "curl"  => '',
-    "gzip"  => '',
-    "id"    => '',
-    "stat"  => '',
+    "php"    => '',
+    "curl"   => '',
+    "gzip"   => '',
+    "id"     => '',
+    "stat"   => '',
+    "python" => '$(which python3)',
 );
 
 // List of local interfaces


### PR DESCRIPTION
The plugin broke with 5902ca9 when changing to python 3

`pip` is needed to be kept installed, and python path added to `$pathToExternals`