### PR TITLE
Initialize ruTorrent plugins on launch

### DIFF
--- a/rootfs/tpls/etc/rtorrent/.rtlocal.rc
+++ b/rootfs/tpls/etc/rtorrent/.rtlocal.rc
@@ -42,3 +42,6 @@ log.add_output = "@RT_LOG_LEVEL@","log"
 log.add_output = "rpc_events","log"
 #log.execute = (cat,(cfg.logs),"execute.log")
 #log.xmlrpc = (cat,(cfg.logs),"xmlrpc.log")
+
+# Initialize plugins
+execute2 = {sh,-c,/usr/bin/php7 /var/www/rutorrent/php/initplugins.php rtorrent &}


### PR DESCRIPTION
Fixes #71 

Add the execute command to initialize the ruTorrent plugins on launch.

Directory structure of a clean launch without the command:

```
$ tree data/rutorrent/share/
data/rutorrent/share/
├── torrents
└── users

2 directories, 0 files
```

Directory structure of a clean launch with the command:
```
$ tree data/rutorrent/share/
data/rutorrent/share/
├── torrents
└── users
    └── rtorrent
        ├── settings
        │   ├── erasedata
        │   ├── extsearch.dat
        │   ├── loginmgr.dat
        │   ├── rss
        │   │   └── cache
        │   │       └── info
        │   ├── rtorrent.dat
        │   ├── scheduler.dat
        │   └── trafic
        │       ├── torrents
        │       └── trackers
        └── torrents

11 directories, 5 files
```