### PR TITLE
ifconfig.me as fallback for automatic WAN_IP determination

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/with-contenv sh
 
 WAN_IP=${WAN_IP:-$(dig +short myip.opendns.com @resolver1.opendns.com)}
+WAN_IP=${WAN_IP:-$(curl ifconfig.me)}
 printf "%s" "$WAN_IP" > /var/run/s6/container_environment/WAN_IP
 
 TZ=${TZ:-UTC}


### PR DESCRIPTION
Unfortunately,
```
dig +short myip.opendns.com @resolver1.opendns.com
```
does not return anything when routing the traffic through certain VPN providers.
Especially using a VPN is a situation where automatic determination of `$WAN_IP` is important, though.

How about adding a fallback by using `curl ifconfig.me`?