### PR TITLE
Added php posix library for autodl plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,6 +261,7 @@ RUN apk --update --no-cache add \
     php7-mbstring \
     php7-openssl \
     php7-phar \
+    php7-posix \
     php7-session \
     php7-sockets \
     php7-xml \


### PR DESCRIPTION
First of all - you made a great rtorrent/rutorrent container, thanks for sharing :)

I wanted to use it along with autodl-irssi and it's rutorrent plugin. However, I run into a problem where the rutorrent plugin could not initialize properly (could not read configuration files). During troubleshooting I found it it was due to missing php-posix library in the container. The responsible line is:

https://github.com/autodl-community/autodl-rutorrent/blob/ffeebe104cdfe309b96f40ebb574840a877f367c/getConf.php#L42

I confirmed the fix is working by building a test container with this library as an additional layer on top:

```
FROM crazymax/rtorrent-rutorrent:latest
RUN apk --update --no-cache add php7-posix
```

So I thought I'd make a pull request as well. Would you consider including this into your build?