### PR TITLE
Added XMLRPC_SIZE_LIMIT as a global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Image: crazymax/rtorrent-rutorrent:latest
 * `LOG_IP_VAR`: Use another variable to retrieve the remote IP address for access [log_format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) on Nginx. (default `remote_addr`)
 * `XMLRPC_AUTHBASIC_STRING`: Message displayed during validation of XMLRPC Basic Auth (default `rTorrent XMLRPC restricted access`)
 * `XMLRPC_PORT`: XMLRPC port through nginx over SCGI socket (default `8000`)
+* `XMLRPC_SIZE_LIMIT`: Maximum body size of XMLRPC calls (default `1M`)
 * `RUTORRENT_AUTHBASIC_STRING`: Message displayed during validation of ruTorrent Basic Auth (default `ruTorrent restricted access`)
 * `RUTORRENT_PORT`: ruTorrent HTTP port (default `8080`)
 * `WEBDAV_AUTHBASIC_STRING`: Message displayed during validation of WebDAV Basic Auth (default `WebDAV restricted access`)

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -13,6 +13,7 @@ MAX_FILE_UPLOADS=${MAX_FILE_UPLOADS:-50}
 REAL_IP_FROM=${REAL_IP_FROM:-0.0.0.0/32}
 REAL_IP_HEADER=${REAL_IP_HEADER:-X-Forwarded-For}
 LOG_IP_VAR=${LOG_IP_VAR:-remote_addr}
+XMLRPC_SIZE_LIMIT=${XMLRPC_SIZE_LIMIT:-1M}
 
 XMLRPC_AUTHBASIC_STRING=${XMLRPC_AUTHBASIC_STRING:-rTorrent XMLRPC restricted access}
 RUTORRENT_AUTHBASIC_STRING=${RUTORRENT_AUTHBASIC_STRING:-ruTorrent restricted access}
@@ -81,6 +82,7 @@ echo "Setting Nginx XMLRPC over SCGI configuration..."
 sed -e "s!@XMLRPC_AUTHBASIC_STRING@!$XMLRPC_AUTHBASIC_STRING!g" \
   -e "s!@XMLRPC_PORT@!$XMLRPC_PORT!g" \
   -e "s!@XMLRPC_HEALTH_PORT@!$XMLRPC_HEALTH_PORT!g" \
+  -e "s!@XMLRPC_SIZE_LIMIT@!$XMLRPC_SIZE_LIMIT!g" \
   /tpls/etc/nginx/conf.d/rpc.conf > /etc/nginx/conf.d/rpc.conf
 
 # Nginx ruTorrent
@@ -157,6 +159,7 @@ echo "Checking rTorrent local configuration..."
 sed -e "s!@RT_LOG_LEVEL@!$RT_LOG_LEVEL!g" \
   -e "s!@RT_DHT_PORT@!$RT_DHT_PORT!g" \
   -e "s!@RT_INC_PORT@!$RT_INC_PORT!g" \
+  -e "s!@XMLRPC_SIZE_LIMIT@!$XMLRPC_SIZE_LIMIT!g" \
   /tpls/etc/rtorrent/.rtlocal.rc > /etc/rtorrent/.rtlocal.rc
 if [ "${RT_LOG_EXECUTE}" = "true" ]; then
   echo "  Enabling rTorrent execute log..."

--- a/rootfs/tpls/.rtorrent.rc
+++ b/rootfs/tpls/.rtorrent.rc
@@ -13,9 +13,6 @@ throttle.max_uploads.set = 15
 throttle.global_down.max_rate.set_kb = 0
 throttle.global_up.max_rate.set_kb = 0
 
-# XMLRPC size limit
-network.xmlrpc.size_limit.set = 4M
-
 # Enable DHT support for trackerless torrents or when all trackers are down
 # May be set to "disable" (completely disable DHT), "off" (do not start DHT),
 # "auto" (start and stop DHT as needed), or "on" (start DHT immediately)

--- a/rootfs/tpls/etc/nginx/conf.d/rpc.conf
+++ b/rootfs/tpls/etc/nginx/conf.d/rpc.conf
@@ -7,6 +7,8 @@ server {
     auth_basic "@XMLRPC_AUTHBASIC_STRING@";
     auth_basic_user_file /passwd/rpc.htpasswd;
 
+    client_max_body_size @XMLRPC_SIZE_LIMIT@;
+
     location / {
         include /etc/nginx/scgi_params;
         scgi_pass unix:/var/run/rtorrent/scgi.socket;

--- a/rootfs/tpls/etc/rtorrent/.rtlocal.rc
+++ b/rootfs/tpls/etc/rtorrent/.rtlocal.rc
@@ -34,6 +34,9 @@ network.port_random.set = no
 # UDP port to use for DHT
 dht.port.set = @RT_DHT_PORT@
 
+# XMLRPC size limit
+network.xmlrpc.size_limit.set = @XMLRPC_SIZE_LIMIT@
+
 # Logging
 ## levels = critical error warn notice info debug
 ## groups = connection_* dht_* peer_* rpc_* storage_* thread_* tracker_* torrent_*


### PR DESCRIPTION
By default, NGINX only allows body's of 1M. Currently, there is a setting in the .rtorrent.rc file for XMLRPC size limit, which is only effective below 1M because above 1M, NGINX steps in and disallows the request with error 413 Request Entity Too Large.