### PR TITLE
Add service labels for http.routers

### DIFF
--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -71,12 +71,14 @@ services:
       - "traefik.http.routers.rutorrent.tls=true"
       - "traefik.http.routers.rutorrent.tls.certresolver=letsencrypt"
       - "traefik.http.routers.rutorrent.tls.domains[0].main=rutorrent.example.com"
+      - "traefik.http.routers.rutorrent.service=rutorrent"
       - "traefik.http.services.rutorrent.loadbalancer.server.port=${RUTORRENT_PORT}"
       - "traefik.http.routers.webdav.entrypoints=https"
       - "traefik.http.routers.webdav.rule=Host(`webdav.example.com`)"
       - "traefik.http.routers.webdav.tls=true"
       - "traefik.http.routers.webdav.tls.certresolver=letsencrypt"
       - "traefik.http.routers.webdav.tls.domains[0].main=webdav.example.com"
+      - "traefik.http.routers.webdav.service=webdav"
       - "traefik.http.services.webdav.loadbalancer.server.port=${WEBDAV_PORT}"
     ulimits:
       nproc: 65535


### PR DESCRIPTION
Fixes #81 

Resolve problems with container runtime

```
rtorrent-rutorrent_geoip-updater_1 exited with code 1
traefik_1             | time="2021-07-26T00:20:52Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=rutorrent
traefik_1             | time="2021-07-26T00:20:52Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:20:52Z" level=info msg="Skipping same configuration" providerName=docker
traefik_1             | time="2021-07-26T00:20:53Z" level=error msg="HTTP challenge is not enabled" routerName=acme-http@internal entryPointName=http
traefik_1             | time="2021-07-26T00:21:06Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=rutorrent
traefik_1             | time="2021-07-26T00:21:06Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:21:06Z" level=info msg="Skipping same configuration" providerName=docker
rtorrent-rutorrent_geoip-updater_1 exited with code 1
traefik_1             | time="2021-07-26T00:21:06Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=rutorrent
traefik_1             | time="2021-07-26T00:21:06Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:21:06Z" level=info msg="Skipping same configuration" providerName=docker
traefik_1             | time="2021-07-26T00:21:33Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=rutorrent
traefik_1             | time="2021-07-26T00:21:33Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:21:33Z" level=info msg="Skipping same configuration" providerName=docker
rtorrent-rutorrent_geoip-updater_1 exited with code 1
traefik_1             | time="2021-07-26T00:21:34Z" level=error msg="Could not define the service name for the router: too many services" routerName=rutorrent providerName=docker
traefik_1             | time="2021-07-26T00:21:34Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:21:34Z" level=info msg="Skipping same configuration" providerName=docker
traefik_1             | time="2021-07-26T00:22:26Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=rutorrent
traefik_1             | time="2021-07-26T00:22:26Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:22:26Z" level=info msg="Skipping same configuration" providerName=docker
rtorrent-rutorrent_geoip-updater_1 exited with code 1
traefik_1             | time="2021-07-26T00:22:27Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=rutorrent
traefik_1             | time="2021-07-26T00:22:27Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=webdav
traefik_1             | time="2021-07-26T00:22:27Z" level=info msg="Skipping same configuration" providerName=docker
```