### PR TITLE
Set S6_KILL_GRACETIME to 10 seconds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -252,6 +252,7 @@ COPY --from=src-mmdb /src /var/mmdb
 
 ENV PYTHONPATH="$PYTHONPATH:/var/www/rutorrent" \
   S6_BEHAVIOUR_IF_STAGE2_FAILS="2" \
+  S6_KILL_GRACETIME="10000" \
   TZ="UTC" \
   PUID="1000" \
   PGID="1000"


### PR DESCRIPTION
Set S6_KILL_GRACETIME to 10 seconds in order to give ample time to rtorrent to shutdown properly before being SIGKILL

fixes #140
fixes #123 