### PR TITLE
Move download directory configuration to .rtorrent.rc

### DIFF
--- a/rootfs/tpls/.rtorrent.rc
+++ b/rootfs/tpls/.rtorrent.rc
@@ -1,3 +1,11 @@
+# Set default download paths
+method.insert = cfg.download, private|const|string, (cat,"/downloads/")
+method.insert = cfg.download_complete, private|const|string, (cat,(cfg.download),"complete/")
+method.insert = cfg.download_temp, private|const|string, (cat,(cfg.download),"temp/")
+
+# Default directory to save the downloaded torrents
+directory.default.set = (cat,(cfg.download_temp))
+
 # Maximum and minimum number of peers to connect to per torrent
 throttle.min_peers.normal.set = 1
 throttle.max_peers.normal.set = 100

--- a/rootfs/tpls/etc/rtorrent/.rtlocal.rc
+++ b/rootfs/tpls/etc/rtorrent/.rtlocal.rc
@@ -3,9 +3,6 @@ system.daemon.set = true
 
 # Instance layout
 method.insert = cfg.basedir, private|const|string, (cat,"/data/rtorrent/")
-method.insert = cfg.download, private|const|string, (cat,"/downloads/")
-method.insert = cfg.download_complete, private|const|string, (cat,(cfg.download),"complete/")
-method.insert = cfg.download_temp, private|const|string, (cat,(cfg.download),"temp/")
 method.insert = cfg.logs, private|const|string, (cat,(cfg.basedir),"log/")
 method.insert = cfg.session, private|const|string, (cat,(cfg.basedir),".session/")
 method.insert = cfg.watch, private|const|string, (cat,(cfg.basedir),"watch/")
@@ -13,9 +10,6 @@ method.insert = cfg.rundir, private|const|string, (cat,"/var/run/rtorrent/")
 
 # Gets the full path of data of a torrent (it's a workaround for the possibly empty 'd.base_path' attribute)
 method.insert = d.data_path, simple, "if=(d.is_multi_file), (cat,(d.directory),/), (cat,(d.directory),/,(d.name))"
-
-# Default directory to save the downloaded torrents
-directory.default.set = (cat,(cfg.download_temp))
 
 # Default session directory
 session.path.set = (cat,(cfg.session))


### PR DESCRIPTION
This addresses the issue of download paths not being easily configurable (#105, #7, #44, #57). 

As @crazy-max said in his comment on #105 the conventional solution here is to use bind-mounts rather than changing directories in-solution. 

@hollanbm, however, raised an important scenario in which that is not applicable. If this container needs to communicate paths to external services, simply using a bind mount is not a viable solution. One might think it's just easy enough to add the `/downloads` mount on any other container that needs access to the path, but this breaks hardlinking. A file can't be hardlinked across bind mounts. As such, the only solution is to change the paths in the configuration file. 

This PR simply moves the configuration of download paths from `.rtlocal.rc`, which is effectively read-only, to `.rtorrent.rc`, which can modified by the user without having to rebuild the container. 