### PR TITLE
Configure xml-rpc correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,9 @@ RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/xmlrpc
 COPY --from=src-xmlrpc /src .
-RUN ./configure
+RUN ./configure \
+   --disable-wininet-client \
+   --disable-libwww-client
 RUN make -j$(nproc)
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)


### PR DESCRIPTION
`xmlrpc-c` is not configured properly. It will cause a very significant performance regression, if the `wininet` and `libwww` clients are not disabled. We want `xmlrpc-c` to use `curl` because it's razor fast and stable. These changes require testing before being merged. I don't have time to test it. The change value is of high importance, which is why I rushed the pull request.