### PR TITLE
Make rtorrent and libtorrent with -O2 -flto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN ./configure \
    --disable-wininet-client \
    --disable-libwww-client
 RUN make -j$(nproc)
-RUN make install -j$(nproc)
+RUN make install -j$(nproc) CXXFLAGS="-flto"
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)
 RUN tree ${DIST_PATH}
 
@@ -159,7 +159,7 @@ RUN ./autogen.sh
 RUN ./configure \
   --with-posix-fallocate
 RUN make -j$(nproc)
-RUN make install -j$(nproc)
+RUN make install -j$(nproc) CXXFLAGS="-O2 -flto"
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)
 RUN tree ${DIST_PATH}
 
@@ -169,7 +169,7 @@ RUN ./autogen.sh
 RUN ./configure \
   --with-xmlrpc-c \
   --with-ncurses
-RUN make -j$(nproc)
+RUN make -j$(nproc) CXXFLAGS="-O2 -flto"
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)
 RUN tree ${DIST_PATH}


### PR DESCRIPTION
rTorrent, libTorrent and xmlrpc support link time optimizations. It's safe to do this. Make rTorrent and libTorrent with Level 2 optimizations. (default is no optimization) This significantly improves performance and reduces code size.