### PR TITLE
ruTorrent v4.0-stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ARG RTORRENT_VERSION=v0.9.8
 ARG MKTORRENT_VERSION=v1.1
 ARG GEOIP2_PHPEXT_VERSION=1.3.1
 
-# 3.10
-ARG RUTORRENT_VERSION=954479ffd00eb58ad14f9a667b3b9b1e108e80a2
+# v4.0-stable
+ARG RUTORRENT_VERSION=06222a00375bdd0f1f1b5b58bda29e7025316428
 ARG GEOIP2_RUTORRENT_VERSION=9f7b59e29bc472eec8c3943d7646bf9462577b16
 
 ARG ALPINE_VERSION=3.17
@@ -197,7 +197,8 @@ RUN tree ${DIST_PATH}
 FROM crazymax/alpine-s6:${ALPINE_S6_VERSION}
 COPY --from=builder /dist /
 COPY --from=src-rutorrent --chown=nobody:nogroup /src /var/www/rutorrent
-COPY --from=src-geoip2-rutorrent --chown=nobody:nogroup /src /var/www/rutorrent/plugins/geoip2
+# FIXME: https://github.com/Micdu70/geoip2-rutorrent not compatible with ruTorrent 4
+#COPY --from=src-geoip2-rutorrent --chown=nobody:nogroup /src /var/www/rutorrent/plugins/geoip2
 COPY --from=src-mmdb /src /var/mmdb
 
 ENV PYTHONPATH="$PYTHONPATH:/var/www/rutorrent" \

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -199,19 +199,19 @@ echo "Bootstrapping ruTorrent configuration..."
 cat > /var/www/rutorrent/conf/config.php <<EOL
 <?php
 
-// For snoopy client
-@define('HTTP_USER_AGENT', '${RU_HTTP_USER_AGENT}', true);
-@define('HTTP_TIME_OUT', ${RU_HTTP_TIME_OUT}, true);
-@define('HTTP_USE_GZIP', ${RU_HTTP_USE_GZIP}, true);
+// for snoopy client
+\$httpUserAgent = '${RU_HTTP_USER_AGENT}';
+\$httpTimeOut = ${RU_HTTP_TIME_OUT};
+\$httpUseGzip = ${RU_HTTP_USE_GZIP};
 
-@define('RPC_TIME_OUT', ${RU_RPC_TIME_OUT}, true);
+// for xmlrpc actions
+\$rpcTimeOut = ${RU_RPC_TIME_OUT};
+\$rpcLogCalls = ${RU_LOG_RPC_CALLS};
+\$rpcLogFaults = ${RU_LOG_RPC_FAULTS};
 
-@define('LOG_RPC_CALLS', ${RU_LOG_RPC_CALLS}, true);
-@define('LOG_RPC_FAULTS', ${RU_LOG_RPC_FAULTS}, true);
-
-// For php
-@define('PHP_USE_GZIP', ${RU_PHP_USE_GZIP}, true);
-@define('PHP_GZIP_LEVEL', ${RU_PHP_GZIP_LEVEL}, true);
+// for php
+\$phpUseGzip = ${RU_PHP_USE_GZIP};
+\$phpGzipLevel = ${RU_PHP_GZIP_LEVEL};
 
 // Rand for schedulers start, +0..X seconds
 \$schedule_rand = ${RU_SCHEDULE_RAND};
@@ -234,6 +234,7 @@ cat > /var/www/rutorrent/conf/config.php <<EOL
 \$scgi_port = 0;
 \$scgi_host = "unix:///var/run/rtorrent/scgi.socket";
 \$XMLRPCMountPoint = "/RPC2"; // DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
+\$throttleMaxSpeed = 327625*1024; // DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
 \$pathToExternals = array(
     "php"    => '',
@@ -262,6 +263,9 @@ cat > /var/www/rutorrent/conf/config.php <<EOL
 \$canUseXSendFile = false;
 
 \$locale = '${RU_LOCALE}';
+
+\$enableCSRFCheck = false; // If true then Origin and Referer will be checked
+\$enabledOrigins = array(); // List of enabled domains for CSRF check (only hostnames, without protocols, port etc.). If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST
 EOL
 chown nobody:nogroup "/var/www/rutorrent/conf/config.php"
 
@@ -308,7 +312,7 @@ fi
 echo "Checking ruTorrent custom plugins..."
 plugins=$(ls -l /data/rutorrent/plugins | grep -E '^d' | awk '{print $9}')
 for plugin in ${plugins}; do
-  if [ "${plugin}" == "theme" ]; then
+  if [ "${plugin}" = "theme" ]; then
     echo "  WARNING: theme plugin cannot be overriden"
     continue
   fi


### PR DESCRIPTION
fixes https://github.com/crazy-max/docker-rtorrent-rutorrent/issues/178
closes #205 

Update ruTorrent to v4.0-stable: https://github.com/Novik/ruTorrent/releases/tag/v4.0-stable cc @stickz

[geoip2-rutorrent](https://github.com/Micdu70/geoip2-rutorrent) is not (yet) compatible with ruTorrent 4 so needs to disable it in the meantime cc @Micdu70:

```
2023/01/07 20:54:10 [error] 550#550: *4 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function getPluginConf() in /var/www/rutorrent/plugins/geoip2/init.php:11
Stack trace:
#0 /var/www/rutorrent/php/getplugins.php(496): require_once()
#1 {main}
```