### PR TITLE
rtorrent.rc: fix delete data when removing torrent issue

### DIFF
--- a/rootfs/tpls/.rtorrent.rc
+++ b/rootfs/tpls/.rtorrent.rc
@@ -59,5 +59,5 @@ method.insert = d.get_finished_dir, simple, "cat=$cfg.download_complete=,$d.cust
 method.insert = d.move_to_complete, simple, "d.directory.set=$argument.1=; execute=mkdir,-p,$argument.1=; execute=mv,-u,$argument.0=,$argument.1=; d.save_full_session="
 method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$d.get_finished_dir="
 
-# Erase data when torrent deleted (no need erasedata plugin on ruTorrent)
-method.set_key = event.download.erased,delete_erased,"execute=rm,-rf,--,$d.data_path="
+# Uncomment if you always want to delete data when removing a torrent
+#method.set_key = event.download.erased,delete_erased,"execute=rm,-rf,--,$d.data_path="


### PR DESCRIPTION
Minor PR which comments out a line in `.rtorrent.rc` defining that when a torrent is removed, the data is always deleted. This is quite controversal as you have the `erasedata` plugin for that scenario. So, for those who actually wants to always delete data when removing a torrent, they can simply uncomment the line and skip using the `erasedata` plugin.

Tested and it works as intended, similar to the findings in https://github.com/crazy-max/docker-rtorrent-rutorrent/issues/199

Related issue which will be fixed: https://github.com/crazy-max/docker-rtorrent-rutorrent/issues/199
PR which can be closed after merging: https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/203