### PR TITLE
Remove erase data workaround

### DIFF
--- a/rootfs/tpls/.rtorrent.rc
+++ b/rootfs/tpls/.rtorrent.rc
@@ -58,6 +58,3 @@ schedule2 = monitor_diskspace, 15, 60, ((close_low_diskspace,1000M))
 method.insert = d.get_finished_dir, simple, "cat=$cfg.download_complete=,$d.custom1="
 method.insert = d.move_to_complete, simple, "d.directory.set=$argument.1=; execute=mkdir,-p,$argument.1=; execute=mv,-u,$argument.0=,$argument.1=; d.save_full_session="
 method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$d.get_finished_dir="
-
-# Erase data when torrent deleted (no need erasedata plugin on ruTorrent)
-method.set_key = event.download.erased,delete_erased,"execute=rm,-rf,--,$d.data_path="


### PR DESCRIPTION
This workaround is no longer desirable, as discussed here: https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/225#issuecomment-1500285041

closes #199
closes #203
closes #225