### PR TITLE
Install php81-dom for ruTorrent v4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,6 +237,7 @@ RUN apk --update --no-cache add \
     php81-cli \
     php81-ctype \
     php81-curl \
+    php81-dom \
     php81-fpm \
     php81-json \
     php81-mbstring \


### PR DESCRIPTION
The `php81-dom` extension is required for ruTorrent v4.1 to function properly. https://github.com/Novik/ruTorrent/issues/2500

`v4.1.3` throws an error when trying to update RSS Feeds. `v4.1.4` will be released next and fix this issue. However, it's still highly recommended to include this extension for optimization. See #236. It wasn't enough to just include `php81-xml`. Alpine puts the DOM module into a separate package. Mentioning PR https://github.com/Novik/ruTorrent/pull/2498 as well for reference.