### PR TITLE
Fix permissions of /tmp/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,7 +263,8 @@ RUN apk --update --no-cache add \
   && addgroup -g ${PGID} rtorrent \
   && adduser -D -H -u ${PUID} -G rtorrent -s /bin/sh rtorrent \
   && curl --version \
-  && rm -rf /tmp/*
+  && rm -rf /tmp/* \
+  && chown ${PUID}:${PGID} /tmp/
 
 COPY rootfs /
 


### PR DESCRIPTION
When pulling this docker image on Unraid, and after each update, the `nginx` server fails to load due to permissions issues of `/tmp`:
```
nginx: [emerg] mkdir() "/tmp/nginx" failed (13: Permission denied)
```

This commit chown's the /tmp/ folder to the right permissions so nginx can start correctly