### PR TITLE
rTorrent: Improve session saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Image: crazymax/rtorrent-rutorrent:latest
 * `RT_LOG_LEVEL`: rTorrent log level (default `info`)
 * `RT_LOG_EXECUTE`: Log executed commands to `/data/rtorrent/log/execute.log` (default `false`)
 * `RT_LOG_XMLRPC`: Log XMLRPC queries to `/data/rtorrent/log/xmlrpc.log` (default `false`)
+* `RT_SESSION_SAVE_SECONDS`: Seconds between writing torrent information to disk (default `3600`)
 * `RT_DHT_PORT`: DHT UDP port (`dht.port.set`, default `6881`)
 * `RT_INC_PORT`: Incoming connections (`network.port_range.set`, default `50000`)
 
@@ -328,6 +329,18 @@ resolve your public IP address. Here are some commands you can use:
 * `dig +short myip.opendns.com @resolver1.opendns.com`
 * `curl -s ifconfig.me`
 * `curl -s ident.me` 
+
+### Configure rTorrent session saving
+
+`RT_SESSION_SAVE_SECONDS` is the seconds between writing torrent information to disk.
+The default is 3600 seconds which equals 1 hour. rTorrent has a bad default of 20 minutes.
+Twenty minutes is bad for the lifespan of SSDs and greatly reduces torrent throughput.
+
+It is no longer possible to lose torrents added through ruTorrent on this docker container.
+Only torrent statistics are lost during a crash. (Ratio, Total Uploaded & Downloaded etc.)
+
+Higher values will reduce disk usage, at the cost of minor stat loss during a crash.
+Consider increasing to 10800 seconds (3 hours) if running thousands of torrents.
 
 ## Upgrade
 

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -24,6 +24,7 @@ WEBDAV_AUTHBASIC_STRING=${WEBDAV_AUTHBASIC_STRING:-WebDAV restricted access}
 RT_LOG_LEVEL=${RT_LOG_LEVEL:-info}
 RT_LOG_EXECUTE=${RT_LOG_EXECUTE:-false}
 RT_LOG_XMLRPC=${RT_LOG_XMLRPC:-false}
+RT_SESSION_SAVE_SECONDS=${RT_SESSION_SAVE_SECONDS:-3600}
 
 RU_REMOVE_CORE_PLUGINS=${RU_REMOVE_CORE_PLUGINS:-httprpc}
 RU_HTTP_USER_AGENT=${RU_HTTP_USER_AGENT:-Mozilla/5.0 (Windows NT 6.0; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0}
@@ -178,6 +179,7 @@ sed -e "s!@RT_LOG_LEVEL@!$RT_LOG_LEVEL!g" \
   -e "s!@RT_DHT_PORT@!$RT_DHT_PORT!g" \
   -e "s!@RT_INC_PORT@!$RT_INC_PORT!g" \
   -e "s!@XMLRPC_SIZE_LIMIT@!$XMLRPC_SIZE_LIMIT!g" \
+  -e "s!@RT_SESSION_SAVE_SECONDS@!$RT_SESSION_SAVE_SECONDS!g" \
   /tpls/etc/rtorrent/.rtlocal.rc > /etc/rtorrent/.rtlocal.rc
 if [ "${RT_LOG_EXECUTE}" = "true" ]; then
   echo "  Enabling rTorrent execute log..."

--- a/rootfs/tpls/etc/rtorrent/.rtlocal.rc
+++ b/rootfs/tpls/etc/rtorrent/.rtlocal.rc
@@ -37,6 +37,12 @@ dht.port.set = @RT_DHT_PORT@
 # XMLRPC size limit
 network.xmlrpc.size_limit.set = @XMLRPC_SIZE_LIMIT@
 
+# Configure session saving interval to balance disk usage and torrent information accuracy
+schedule2 = session_save, 1200, @RT_SESSION_SAVE_SECONDS@, ((session.save))
+
+# Save torrents immediately to prevent losing them between session saving intervals
+method.set_key = event.download.inserted, 2_save_session, ((d.save_full_session))
+
 # Logging
 ## levels = critical error warn notice info debug
 ## groups = connection_* dht_* peer_* rpc_* storage_* thread_* tracker_* torrent_*


### PR DESCRIPTION
This commit improves session saving support for rTorrent to prevent unnecessary loss of torrent files. It also increases the session saving interval from 20 minutes to 1 hour to reduce disk i/o usage with thousands of torrents. Session saving is a very intensive task. Torrents fail to save into session by default when added and can be lost if a crash occurs between saving intervals.