### PR TITLE
Drop chown of tpls folder to allow config maps mounted over it

### DIFF
--- a/rootfs/etc/cont-init.d/02-fix-perms.sh
+++ b/rootfs/etc/cont-init.d/02-fix-perms.sh
@@ -22,7 +22,6 @@ chown rtorrent:rtorrent \
 chown -R rtorrent:rtorrent \
   /etc/rtorrent \
   /passwd \
-  /tpls \
   /var/cache/nginx \
   /var/lib/nginx \
   /var/log/nginx \


### PR DESCRIPTION
I run the image inside k8s and use a configmap to use an extended .rtorrent.rc template. As a config map is always read only this chown fails the container startup.
As the templates can be read by the init script anyway I think it's safe to remove the chown and by that allow the use of configmaps in k8s. I hope i do not miss an obvious case where this is needed.