### PR TITLE
rTorrent: Add stability patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN apk --update --no-cache add \
     ncurses-dev \
     nghttp2-dev \
     openssl-dev \
+    patch \
     pcre-dev \
     php81-dev \
     php81-pear \
@@ -141,6 +142,8 @@ RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/libtorrent
 COPY --from=src-libtorrent /src .
+COPY /patches/libtorrent .
+RUN patch -p1 < throttle-fix-0.13.8.patch
 RUN ./autogen.sh
 RUN ./configure \
   --with-posix-fallocate
@@ -151,6 +154,12 @@ RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/rtorrent
 COPY --from=src-rtorrent /src .
+COPY /patches/rtorrent .
+RUN patch -p1 < lockfile-fix.patch \
+  && patch -p1 < scgi-fix.patch \
+  && patch -p1 < session-file-fix.patch \
+  && patch -p1 < xmlrpc-fix.patch \
+  && patch -p1 < xmlrpc-logic-fix.patch
 RUN ./autogen.sh
 RUN ./configure \
   --with-xmlrpc-c \

--- a/patches/libtorrent/throttle-fix-0.13.8.patch
+++ b/patches/libtorrent/throttle-fix-0.13.8.patch
@@ -1,0 +1,35 @@
+From 326598abe30a82f8f74794788e11228300a36164 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Fri, 24 Feb 2023 12:57:59 -0500
+Subject: [PATCH] Allow 10 gigabit speed throttles
+
+This commit increases max upload and download speed by 16 times. It allows utilization of 10 gigabit connections.
+---
+ src/torrent/download/resource_manager.cc | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/torrent/download/resource_manager.cc b/src/torrent/download/resource_manager.cc
+index 8ca7b02e..f882a202 100644
+--- a/src/torrent/download/resource_manager.cc
++++ b/src/torrent/download/resource_manager.cc
+@@ -266,16 +266,16 @@ ResourceManager::set_group(iterator itr, uint16_t grp) {
+ 
+ void
+ ResourceManager::set_max_upload_unchoked(unsigned int m) {
+-  if (m > (1 << 16))
+-    throw input_error("Max unchoked must be between 0 and 2^16.");
++  if (m > (1 << 20))
++    throw input_error("Max unchoked must be between 0 and 2^20.");
+ 
+   m_maxUploadUnchoked = m;
+ }
+ 
+ void
+ ResourceManager::set_max_download_unchoked(unsigned int m) {
+-  if (m > (1 << 16))
+-    throw input_error("Max unchoked must be between 0 and 2^16.");
++  if (m > (1 << 20))
++    throw input_error("Max unchoked must be between 0 and 2^20.");
+ 
+   m_maxDownloadUnchoked = m;
+ }

--- a/patches/rtorrent/lockfile-fix.patch
+++ b/patches/rtorrent/lockfile-fix.patch
@@ -1,0 +1,28 @@
+From 812bba81bc049a5f786282b3654cab294b0ef236 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <cyphar@cyphar.com>
+Date: Mon, 20 Jun 2022 19:09:57 +1000
+Subject: [PATCH] utils: lockfile: avoid stack overflow for lockfile buffer
+
+There appears to have been some change on openSUSE (likely some new
+hardening flags for builds, or some glibc hardening) such that incorrect
+buffer handling results in a segfault even if the buffer is never
+overflowed.
+
+Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
+---
+ src/utils/lockfile.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/utils/lockfile.cc b/src/utils/lockfile.cc
+index 7d11d8c99..fac5cb23e 100644
+--- a/src/utils/lockfile.cc
++++ b/src/utils/lockfile.cc
+@@ -98,7 +98,8 @@ Lockfile::try_lock() {
+   int pos = ::gethostname(buf, 255);
+ 
+   if (pos == 0) {
+-    ::snprintf(buf + std::strlen(buf), 255, ":+%i\n", ::getpid());
++    ssize_t len = std::strlen(buf);
++    ::snprintf(buf + len, 255 - len, ":+%i\n", ::getpid());
+     int __UNUSED result = ::write(fd, buf, std::strlen(buf));
+   }

--- a/patches/rtorrent/scgi-fix.patch
+++ b/patches/rtorrent/scgi-fix.patch
@@ -1,0 +1,23 @@
+From f600ba802201da20834751412faafa374ce255c4 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Sep 2023 08:36:15 -0400
+Subject: [PATCH] Increase maximum SCGI request to 16MB
+
+Fixing a problem where xmlrpc-c information fails to update if user is running too many torrents.
+---
+ src/rpc/scgi_task.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rpc/scgi_task.h b/src/rpc/scgi_task.h
+index e75e9e1ea..a42349bf8 100644
+--- a/src/rpc/scgi_task.h
++++ b/src/rpc/scgi_task.h
+@@ -51,7 +51,7 @@ class SCgiTask : public torrent::Event {
+ public:
+   static const unsigned int default_buffer_size = 2047;
+   static const          int max_header_size     = 2000;
+-  static const          int max_content_size    = (2 << 20);
++  static const          int max_content_size    = (2 << 23);
+ 
+   SCgiTask() { m_fileDesc = -1; }
+ 

--- a/patches/rtorrent/session-file-fix.patch
+++ b/patches/rtorrent/session-file-fix.patch
@@ -1,0 +1,46 @@
+From 7594fc942ecd0ed64f7feea24bd54b6fdddba49b Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Sep 2023 10:34:07 -0400
+Subject: [PATCH] Fix saving session files
+
+Resolves a data corruption issue with torrent session during a power loss.
+---
+ src/core/download_store.cc | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/core/download_store.cc b/src/core/download_store.cc
+index 536dba10a..e111b41bc 100644
+--- a/src/core/download_store.cc
++++ b/src/core/download_store.cc
+@@ -40,6 +40,7 @@
+ 
+ #include <fstream>
+ #include <stdio.h>
++#include <fcntl.h>
+ #include <unistd.h>
+ #include <rak/error_number.h>
+ #include <rak/path.h>
+@@ -102,6 +103,7 @@ bool
+ DownloadStore::write_bencode(const std::string& filename, const torrent::Object& obj, uint32_t skip_mask) {
+   torrent::Object tmp;
+   std::fstream output(filename.c_str(), std::ios::out | std::ios::trunc);
++  int fd = -1;
+ 
+   if (!output.is_open())
+     goto download_store_save_error;
+@@ -121,6 +123,15 @@ DownloadStore::write_bencode(const std::string& filename, const torrent::Object&
+     goto download_store_save_error;
+ 
+   output.close();
++  
++  // Ensure that the new file is actually written to the disk
++  fd = ::open(filename.c_str(), O_WRONLY);
++  if (fd < 0)
++    goto download_store_save_error;
++
++  fsync(fd);
++  ::close(fd);
++
+   return true;
+ 
+ download_store_save_error:

--- a/patches/rtorrent/xmlrpc-fix.patch
+++ b/patches/rtorrent/xmlrpc-fix.patch
@@ -1,0 +1,32 @@
+From 4abaa260ce758accc1866d1b0f744dc370ba3254 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 27 Nov 2021 23:00:20 -0500
+Subject: [PATCH] Fix common rtorrent xml-rpc crash when trying to queue an invalid task
+
+Instead of throwing an internal error and terminating the client, it's better not to queue the invalid task in the first place.
+`C Caught internal_error: 'priority_queue_insert(...) called on an invalid item.'.`
+---
+ src/rpc/command_scheduler_item.cc | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/rpc/command_scheduler_item.cc b/src/rpc/command_scheduler_item.cc
+index 42a6ef43..af04a884 100644
+--- a/src/rpc/command_scheduler_item.cc
++++ b/src/rpc/command_scheduler_item.cc
+@@ -53,10 +53,14 @@ CommandSchedulerItem::enable(rak::timer t) {
+ 
+   if (is_queued())
+     disable();
++    
++  // Don't schedule invalid tasks for rpc commands
++  if (!m_task.is_valid())
++    return;
+ 
+   // If 'first' is zero then we execute the task
+   // immediately. ''interval()'' will not return zero so we never end
+-  // up in an infinit loop.
++  // up in an infinite loop.
+   m_timeScheduled = t;
+   priority_queue_insert(&taskScheduler, &m_task, t);
+ }
+

--- a/patches/rtorrent/xmlrpc-logic-fix.patch
+++ b/patches/rtorrent/xmlrpc-logic-fix.patch
@@ -1,0 +1,23 @@
+From 898d0b21792c9f021a098961c6d47e07a4b188f1 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Mon, 2 Oct 2023 17:02:06 -0400
+Subject: [PATCH] Resolve xmlrpc logic crash
+
+Resolves a rtorrent crash caused by sending invalid xmlrpc logic.
+---
+ src/rpc/command_impl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rpc/command_impl.h b/src/rpc/command_impl.h
+index b7ec9168c..a7838d49c 100644
+--- a/src/rpc/command_impl.h
++++ b/src/rpc/command_impl.h
+@@ -63,7 +63,7 @@ template <> struct target_type_id<core::Download*, core::Download*> { static con
+ template <> inline bool
+ is_target_compatible<target_type>(const target_type& target) { return true; }
+ template <> inline bool
+-is_target_compatible<torrent::File*>(const target_type& target) { return target.first == command_base::target_file || command_base::target_file_itr; }
++is_target_compatible<torrent::File*>(const target_type& target) { return (target.first == command_base::target_file || command_base::target_file_itr) && target.first == target_type_id<torrent::File*>::value; }
+ 
+ template <> inline target_type
+ get_target_cast<target_type>(target_type target, int type) { return target; }


### PR DESCRIPTION
This commit adds multiple stability patches to rtorrent. I have tested these for multiple months. The reason for modifying the software is to resolve stability issues. The software owner is no longer releasing new versions.

**libtorrent**
- Fixes an issue where the throttle plugin on ruTorrent is required to limit upload/download speed to 1gbps.

**rTorrent**
- Fixes a crash caused by some hardening flags during the build process.
- Fixes a crash caused by ruTorrent sending invalid xmlrpc data to rTorrent.
- Fixes a crash caused by external configurations sending invalid xmlrpc data to rTorrent.
- Fixes an issue where torrent information will not update if too many torrents are running.
- Fixes an issue where a power loss during torrent session saving will corrupt torrents.