### PR TITLE
Improve c-ares & curl build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
 ARG LIBSIG_VERSION=3.0.3
-ARG CARES_VERSION=1.17.2
-ARG CURL_VERSION=7.78.0
+ARG CARES_VERSION=1.24.0
+ARG CURL_VERSION=8.5.0
 ARG XMLRPC_VERSION=01.58.00
 ARG LIBTORRENT_VERSION=v0.13.8
 ARG RTORRENT_VERSION=v0.9.8
@@ -81,6 +81,7 @@ RUN apk --update --no-cache add \
     brotli-dev \
     build-base \
     cppunit-dev \
+    cmake \
     gd-dev \
     geoip-dev \
     libtool \
@@ -110,22 +111,17 @@ RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/cares
 COPY --from=src-cares /src .
-RUN ./configure
-RUN make -j$(nproc) CFLAGS="-O2 -flto"
+RUN cmake . -D CARES_SHARED=ON -D CMAKE_BUILD_TYPE:STRING="Release" -D CMAKE_C_FLAGS_RELEASE:STRING="-O3 -flto=\"$(nproc)\" -pipe"
+RUN cmake --build . --clean-first --parallel $(nproc)
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)
 RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/curl
 COPY --from=src-curl /src .
-RUN ./configure \
-  --enable-ares \
-  --enable-tls-srp \
-  --enable-gnu-tls \
-  --with-brotli \
-  --with-ssl \
-  --with-zlib
-RUN make -j$(nproc) CFLAGS="-O2 -flto -pipe"
+RUN cmake . -D ENABLE_ARES=ON CURL_LTO=ON -D CURL_USE_OPENSSL=ON -D CURL_BROTLI=ON -D BUILD_SHARED_LIBS=ON \
+            -D CMAKE_BUILD_TYPE:STRING="Release" -D CMAKE_C_FLAGS_RELEASE:STRING="-O3 -flto=\"$(nproc)\" -pipe"
+RUN cmake --build . --clean-first --parallel $(nproc)
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)
 RUN tree ${DIST_PATH}


### PR DESCRIPTION
This commit improves the c-ares and curl build process to use cmake instead. This is a much better choice for docker container. We do not require the features GNU Make provides. CMake should also be faster and more stable for testing pull requests.

It also upgrades the c-ares and curl version to receive the latest bug fixes and performance changes. There's been a huge leap forward since the older changes. Put simple, curl 8 is faster.