### PR TITLE
Docker image building improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ on:
       - '*'
     paths-ignore:
       - '**.md'
-  pull_request:
-    paths-ignore:
-      - '**.md'
 
 env:
   DOCKERHUB_SLUG: crazymax/rtorrent-rutorrent

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,0 +1,111 @@
+name: pull
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build_amd64:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/bake-action@v4
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-amd64
+
+  build_arm64:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/bake-action@v4
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-arm64
+
+  build_arm_v6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/bake-action@v4
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-arm-v6
+
+  build_arm_v7:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/bake-action@v4
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-arm-v7

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -30,3 +30,31 @@ target "image-all" {
     "linux/arm64"
   ]
 }
+
+target "image-amd64" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}
+
+target "image-arm64" {
+  inherits = ["image"]
+  platforms = [
+    "linux/arm64"
+  ]
+}
+
+target "image-arm-v6" {
+  inherits = ["image"]
+  platforms = [
+    "linux/arm/v6"
+  ]
+}
+
+target "image-arm-v7" {
+  inherits = ["image"]
+  platforms = [
+    "linux/arm/v7"
+  ]
+}


### PR DESCRIPTION
1. Instead of building all the platforms at once, build them as a separate jobs.
2. Build c-ares and curl with cmake to significantly speed along the build process.
3. Disable build warnings for xmlrpc, libtorrent and rtorrent to speed along the build process.
4. Fixed a critical issue where xmlrpc and libtorrent was not being built with the intended flags.

This should resolve timeout problems for PRs.