### PR TITLE
ruTorrent: Enable 10gbps speed throttles

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ ___
 * [mktorrent](https://github.com/Rudde/mktorrent) installed for ruTorrent create plugin
 * [Traefik](https://github.com/containous/traefik-library-image) Docker image as reverse proxy and creation/renewal of Let's Encrypt certificates (see [this template](examples/traefik))
 * [geoip-updater](https://github.com/crazy-max/geoip-updater) Docker image to download MaxMind's GeoIP2 databases on a time-based schedule for geolocation
+* [ruTorrent throttle plugin](https://github.com/Novik/ruTorrent/wiki/PluginThrottle) with rTorrent support for 10Gbps
 
 ## Build locally
 

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -246,7 +246,7 @@ cat > /var/www/rutorrent/conf/config.php <<EOL
 \$scgi_port = 0;
 \$scgi_host = "unix:///var/run/rtorrent/scgi.socket";
 \$XMLRPCMountPoint = "/RPC2"; // DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
-\$throttleMaxSpeed = 327625*1024; // DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!
+\$throttleMaxSpeed = 327625*1024*8; // DO NOT EDIT THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
 \$pathToExternals = array(
     "php"    => '',


### PR DESCRIPTION
This commit increases the max torrent client speed to 10Gbps, while the ruTorrent throttle plugin is active. This is a follow up to the libtorrent throttle patch.