### PR TITLE
rTorrent: Resolve memory leaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,10 @@ RUN patch -p1 < lockfile-fix.patch \
   && patch -p1 < scgi-fix.patch \
   && patch -p1 < session-file-fix.patch \
   && patch -p1 < xmlrpc-fix.patch \
-  && patch -p1 < xmlrpc-logic-fix.patch
+  && patch -p1 < xmlrpc-logic-fix.patch \
+  && patch -p1 < rtorrent-ml-cg-fix.patch \
+  && patch -p1 < rtorrent-ml-cui-fix.patch \
+  && patch -p1 < rtorrent-ml-dc-fix.patch
 RUN ./autogen.sh
 RUN ./configure --with-xmlrpc-c --with-ncurses
 RUN make -j$(nproc) CXXFLAGS="-w -O3 -flto"

--- a/patches/rtorrent/rtorrent-ml-cg-fix.patch
+++ b/patches/rtorrent/rtorrent-ml-cg-fix.patch
@@ -1,0 +1,74 @@
+From 4f57db8b499b672af19243e159d8c3439e1a5b82 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Dec 2023 07:04:47 -0500
+Subject: [PATCH] Resolve choke groups memory leak
+
+Resolves a memory leak during software initialization with choke groups.
+---
+ src/command_groups.cc  | 11 +++++++++++
+ src/command_helpers.cc |  6 ++++++
+ src/command_helpers.h  |  1 +
+ src/main.cc            |  2 ++
+ 4 files changed, 20 insertions(+)
+
+diff --git a/src/command_groups.cc b/src/command_groups.cc
+index 359a532e5..a0bc40dad 100644
+--- a/src/command_groups.cc
++++ b/src/command_groups.cc
+@@ -381,3 +381,14 @@ initialize_command_groups() {
+                                                                  std::bind(&torrent::choke_queue::heuristics, CHOKE_GROUP(&torrent::choke_group::down_queue))));
+   CMD2_ANY_LIST    ("choke_group.down.heuristics.set", std::bind(&apply_cg_heuristics_set, std::placeholders::_2, false));
+ }
++
++void cleanup_command_groups() {
++#if USE_CHOKE_GROUP
++#else
++  while (!cg_list_hack.empty()) {
++    auto cg = cg_list_hack.back();
++    delete cg;
++    cg_list_hack.pop_back();
++  }
++#endif
++}
+diff --git a/src/command_helpers.cc b/src/command_helpers.cc
+index 54c0b35e4..31599e265 100644
+--- a/src/command_helpers.cc
++++ b/src/command_helpers.cc
+@@ -57,6 +57,12 @@ void initialize_command_tracker();
+ void initialize_command_scheduler();
+ void initialize_command_ui();
+ 
++void cleanup_command_groups();
++
++void cleanup_commands() {
++  cleanup_command_groups();
++}
++
+ void
+ initialize_commands() {
+   initialize_command_dynamic();
+diff --git a/src/command_helpers.h b/src/command_helpers.h
+index a104fbbc4..48e7ea258 100644
+--- a/src/command_helpers.h
++++ b/src/command_helpers.h
+@@ -42,6 +42,7 @@
+ #include "rpc/object_storage.h"
+ 
+ void initialize_commands();
++void cleanup_commands();
+ 
+ //
+ // New std::function based command_base helper functions:
+diff --git a/src/main.cc b/src/main.cc
+index c76558f8f..6f06da3c5 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -510,6 +510,8 @@ main(int argc, char** argv) {
+     lt_log_print(torrent::LOG_CRITICAL, "Caught exception: '%s'.", e.what());
+     return -1;
+   }
++  
++  cleanup_commands();
+ 
+   torrent::log_cleanup();
+ 

--- a/patches/rtorrent/rtorrent-ml-cui-fix.patch
+++ b/patches/rtorrent/rtorrent-ml-cui-fix.patch
@@ -1,0 +1,30 @@
+From 993155c5461164f9eca73c43091865ff32906601 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Dec 2023 06:57:13 -0500
+Subject: [PATCH] Fix curses ui memory leak
+
+Resolves a potential memory leak with the curses UI when filtering torrents
+---
+ src/ui/download_list.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/ui/download_list.cc b/src/ui/download_list.cc
+index f1d6af5c6..7cb0e9a89 100644
+--- a/src/ui/download_list.cc
++++ b/src/ui/download_list.cc
+@@ -272,6 +272,7 @@ DownloadList::receive_view_input(Input type) {
+           std::getline(ss, view_name_var, ',');
+           if (current_view()->name() == rak::trim(view_name_var)) {
+               control->core()->push_log_std("View '" + current_view()->name() + "' can't be filtered.");
++              delete input;
+               return;
+           }
+       }
+@@ -281,6 +282,7 @@ DownloadList::receive_view_input(Input type) {
+     break;
+ 
+   default:
++    delete input;
+     throw torrent::internal_error("DownloadList::receive_view_input(...) Invalid input type.");
+   }
+ 

--- a/patches/rtorrent/rtorrent-ml-dc-fix.patch
+++ b/patches/rtorrent/rtorrent-ml-dc-fix.patch
@@ -1,0 +1,23 @@
+From 7930792e0bd86a1c3d6469f63a3fa0cc39cc0f8f Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Dec 2023 06:59:53 -0500
+Subject: [PATCH] Fix dynamic commands memory leak
+
+Resolves a memory leak with dynamic commands in the .rtorrent.rc file.
+---
+ src/command_dynamic.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/command_dynamic.cc b/src/command_dynamic.cc
+index a8d0ff02f..3d7a123b1 100644
+--- a/src/command_dynamic.cc
++++ b/src/command_dynamic.cc
+@@ -147,7 +147,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
+     throw torrent::input_error("Invalid type.");
+   }
+ 
+-  int cmd_flags = 0;
++  int cmd_flags = rpc::CommandMap::flag_delete_key;
+ 
+   if (!(flags & rpc::object_storage::flag_static))
+     cmd_flags |= rpc::CommandMap::flag_modifiable;


### PR DESCRIPTION
This patch resolves critical memory leaks with the rTorrent software, that can cause an out of memory condition to happen. It has been tested for months and has demonstrated proven memory stability for rTorrent.