### PR TITLE
rTorrent: Resolve memory access crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,7 @@ RUN patch -p1 < throttle-fix-0.13.8.patch \
   && patch -p1 < libtorrent-udns-0.13.8.patch \
   && patch -p1 < libtorrent-scanf-0.13.8.patch
 RUN ./autogen.sh
-RUN ./configure --with-posix-fallocate
+RUN ./configure --with-posix-fallocate --enable-aligned
 RUN make -j$(nproc) CXXFLAGS="-w -O3 -flto"
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)


### PR DESCRIPTION
rTorrent requires the usage of aligned memory access on all platforms (x86 and ARM) to prevent a memory access crash from happening. As such, we need to configure libtorrent with `--enable-aligned` to enable the feature.

This is also more efficient for CPU usage at the cost of slightly more memory consumption.  However, due to the relatively small usage of memory, all platforms will benefit.

More information can be found here: https://github.com/rakshasa/libtorrent/issues/244