### PR TITLE
Add php82-fileinfo package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,6 +230,7 @@ RUN apk --update --no-cache add \
     php82-ctype \
     php82-curl \
     php82-dom \
+    php82-fileinfo \
     php82-fpm \
     php82-mbstring \
     php82-openssl \


### PR DESCRIPTION
The `mime_content_type` function is part of the fileinfo extension:
https://github.com/Novik/ruTorrent/blob/2d67a00b4fde90b4a652c130ed76ac2fc4383fb3/plugins/tracklabels/action.php#L66

Icon upload now works after adding this package.