### PR TITLE
ruTorrent v4.3.0 fix

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -320,6 +320,7 @@ if [ -d "/var/www/rutorrent/plugins/create" ]; then
 \$useExternal = 'mktorrent';
 \$pathToCreatetorrent = '/usr/local/bin/mktorrent';
 \$recentTrackersMaxCount = 15;
+\$useInternalHybrid = true;
 EOL
   chown nobody:nogroup "/var/www/rutorrent/plugins/create/conf.php"
 else


### PR DESCRIPTION
We **must** add `$useInternalHybrid = true;` to the torrent creator configuration file for `ruTorrent v4.3.0` compatibility.