### PR TITLE
nginx: Disable listening for IPV6

### DIFF
--- a/rootfs/tpls/etc/nginx/conf.d/rpc.conf
+++ b/rootfs/tpls/etc/nginx/conf.d/rpc.conf
@@ -1,6 +1,5 @@
 server {
     listen @XMLRPC_PORT@;
-    listen [::]:@XMLRPC_PORT@;
 
     root /dev/null;
 

--- a/rootfs/tpls/etc/nginx/conf.d/rutorrent.conf
+++ b/rootfs/tpls/etc/nginx/conf.d/rutorrent.conf
@@ -1,6 +1,5 @@
 server {
     listen @RUTORRENT_PORT@;
-    listen [::]:@RUTORRENT_PORT@;
 
     root /var/www/rutorrent;
     index index.html;

--- a/rootfs/tpls/etc/nginx/conf.d/webdav.conf
+++ b/rootfs/tpls/etc/nginx/conf.d/webdav.conf
@@ -1,6 +1,5 @@
 server {
     listen @WEBDAV_PORT@;
-    listen [::]:@WEBDAV_PORT@;
 
     root /downloads/complete;
 


### PR DESCRIPTION
fixes #348

There is no point in supporting IPV6 on this docker container. IPV4 is required anyways for rTorrent to function properly.

If the user disables loading the IPV6 kernel module at boot time, the docker container will fail to initialize if nginx is listening for IPV6.