### PR TITLE
Upgrade mktorrent build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG RTORRENT_STICKZ_VERSION
 RUN git fetch origin "${RTORRENT_STICKZ_VERSION}" && git checkout -q FETCH_HEAD
 
 FROM src AS src-mktorrent
-RUN git init . && git remote add origin "https://github.com/esmil/mktorrent.git"
+RUN git init . && git remote add origin "https://github.com/pobrn/mktorrent.git"
 ARG MKTORRENT_VERSION
 RUN git fetch origin "${MKTORRENT_VERSION}" && git checkout -q FETCH_HEAD
 
@@ -150,7 +150,11 @@ RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/mktorrent
 COPY --from=src-mktorrent /src .
-RUN make -j$(nproc) CC=gcc CFLAGS="-w -O3 -flto"
+RUN echo "CC = gcc" >> Makefile	
+RUN echo "CFLAGS = -w -flto -O3" >> Makefile
+RUN echo "USE_PTHREADS = 1" >> Makefile
+RUN echo "USE_OPENSSL = 1" >> Makefile
+RUN make -j$(nproc)
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)
 RUN tree ${DIST_PATH}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ___
 * Ability to add a custom ruTorrent plugin / theme
 * Allow persisting specific configuration for ruTorrent plugins
 * ruTorrent [GeoIP2 plugin](https://github.com/Micdu70/geoip2-rutorrent)
-* [mktorrent](https://github.com/Rudde/mktorrent) installed for ruTorrent create plugin
+* [mktorrent](https://github.com/pobrn/mktorrent) installed for ruTorrent create plugin
 * [Traefik](https://github.com/containous/traefik-library-image) Docker image as reverse proxy and creation/renewal of Let's Encrypt certificates (see [this template](examples/traefik))
 * [geoip-updater](https://github.com/crazy-max/geoip-updater) Docker image to download MaxMind's GeoIP2 databases on a time-based schedule for geolocation
 


### PR DESCRIPTION
Allows for near instantaneous torrent creation by multi-threading the hashing process, provided disk resources are available. We must apply these options directly to the Makefile. This software will not accept environment variables passed by GNU make.

- Remove unnecessary redirect with git clone.
- Properly apply compiler and build flags.
- Use pthreads and openssl for multi-threading.