### PR TITLE
rTorrent: Optimize session saving for new torrents

### DIFF
--- a/rootfs/tpls/etc/rtorrent/.rtlocal.rc
+++ b/rootfs/tpls/etc/rtorrent/.rtlocal.rc
@@ -41,8 +41,8 @@ network.xmlrpc.size_limit.set = @XMLRPC_SIZE_LIMIT@
 schedule2 = session_save, 1200, @RT_SESSION_SAVE_SECONDS@, ((session.save))
 
 # Save torrents immediately to prevent losing them between session saving intervals
-# Schedule task to run in background (with unique hash) to avoid startup impact
-method.set_key = event.download.inserted, 2_save_session, "schedule2 = ((d.hash)), 0, 0, ((d.save_full_session))"
+# Schedule task to run in background (with unique hash) to avoid seeding impact
+method.set_key = event.download.inserted_new, "schedule2 = ((d.hash)), 0, 0, ((d.save_full_session))"
 
 # Configure whether to delay tracker announces at startup
 trackers.delay_scrape = @RT_TRACKER_DELAY_SCRAPE@


### PR DESCRIPTION
- Only run when a new download is inserted (not at startup). This avoids writing the entire torrent session library to disk at startup. We change the event from `event.download.inserted` to `event.download.inserted_new` to improve performance.

- Remove unnecessary 2nd key. The `method.set_key` command does not take a method name. As a result, we should not provide it to avoid warnings. We only need to provide the schedule key.