### PR TITLE
Upgrade to rTorrent v5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ARG GEOIP2_PHPEXT_VERSION=1.3.1
 ARG RUTORRENT_VERSION=9bf6e15c4864a71ff9e9ca5ea689fd001931279b
 ARG GEOIP2_RUTORRENT_VERSION=4ff2bde530bb8eef13af84e4413cedea97eda148
 
-# v5.1-0.9.8-0.13.8
-ARG RTORRENT_STICKZ_VERSION=278362bd83aebbf20be15c29c1d5085f7c383ff5
+# v5.3-0.9.8-0.13.8
+ARG RTORRENT_STICKZ_VERSION=effa2f24b0c6674d9e649dc626b659f4bd43c7b2
 
 ARG ALPINE_VERSION=3.19
 ARG ALPINE_S6_VERSION=${ALPINE_VERSION}-2.2.0.3
@@ -134,7 +134,7 @@ COPY --from=src-rtorrent /src .
 
 WORKDIR /usr/local/src/rtorrent/libtorrent
 RUN ./autogen.sh
-RUN ./configure --with-posix-fallocate --enable-aligned
+RUN ./configure --enable-aligned --disable-instrumentation
 RUN make -j$(nproc) CXXFLAGS="-w -O3 -flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)


### PR DESCRIPTION
**The full changelog between the last tag can be viewed here.**
**Full Changelog**: https://github.com/stickz/rtorrent/compare/v5.1-0.9.8-0.13.8...v5.3-0.9.8-0.13.8

## Version 5.3 Release
The `--disable-instrumentation` configure option for libtorrent now it's works properly. The threads still have instrumentation, so they work properly. All other source code instrumentation is disabled at compile time. This allows the software to perform tasks in the most efficient order and reduces scheduling overhead.

This configure option is an intermediary step. It's highly recommended to use it. In the future, instrumentation will be removed entirely for non-threaded tasks. In the very unlikely event a regression is found, please file an issue report. 

## What's Changed
* libtorrent: Optimize unsigned int datatypes by @stickz in https://github.com/stickz/rtorrent/pull/26
* libtorrent: Disable instrumentation properly by @stickz in https://github.com/stickz/rtorrent/pull/27

**Full Changelog**: https://github.com/stickz/rtorrent/compare/v5.2-0.9.8-0.13.8...v5.3-0.9.8-0.13.8

## Version 5.2 Release
**It is highly recommended to upgrade to this release.** The fallocate feature works better. A critical software crash is also resolved.

1. Removes ~1100 lines of unused code from the project.
2. Removes `--with-posix-fallocate` libtorrent configure option in favour of automation.
3. Optimizes the fallocate feature to perform less redundant tasks at runtime.
4. Fixes a critical software crash with various methods inputted into `.rtorrent.rc`.

## What's Changed
* libtorrent: Optimize fallocate by @stickz in https://github.com/stickz/rtorrent/pull/22
* rTorrent: Use regular iterators instead of bucket-local ones by @stickz in https://github.com/stickz/rtorrent/pull/23
* Cleanup unused popcount functions by @stickz in https://github.com/stickz/rtorrent/pull/24
* Cleanup unused functions in rak namespace by @stickz in https://github.com/stickz/rtorrent/pull/25

**Full Changelog**: https://github.com/stickz/rtorrent/compare/v5.1-0.9.8-0.13.8...v5.2-0.9.8-0.13.8