### PR TITLE
Upgrade to rTorrent v6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ARG GEOIP2_PHPEXT_VERSION=1.3.1
 ARG RUTORRENT_VERSION=9bf6e15c4864a71ff9e9ca5ea689fd001931279b
 ARG GEOIP2_RUTORRENT_VERSION=4ff2bde530bb8eef13af84e4413cedea97eda148
 
-# v5.3-0.9.8-0.13.8
-ARG RTORRENT_STICKZ_VERSION=effa2f24b0c6674d9e649dc626b659f4bd43c7b2
+# v6.0-0.9.8-0.13.8
+ARG RTORRENT_STICKZ_VERSION=f6ef811e50d78c041dd9865698186a2319b3ef88
 
 ARG ALPINE_VERSION=3.19
 ARG ALPINE_S6_VERSION=${ALPINE_VERSION}-2.2.0.3
@@ -134,7 +134,7 @@ COPY --from=src-rtorrent /src .
 
 WORKDIR /usr/local/src/rtorrent/libtorrent
 RUN ./autogen.sh
-RUN ./configure --enable-aligned --disable-instrumentation
+RUN ./configure --enable-aligned --disable-instrumentation --enable-udns
 RUN make -j$(nproc) CXXFLAGS="-w -O3 -flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
 RUN make install -j$(nproc)
 RUN make DESTDIR=${DIST_PATH} install -j$(nproc)


### PR DESCRIPTION
**Full Changelog**: https://github.com/stickz/rtorrent/compare/v5.3-0.9.8-0.13.8...v6.0-0.9.8-0.13.8

## Version 6.0 Release Notes
This release includes a rewrite of the UDNS interface for libtorrent to increase performance and stability of UDP trackers. It can be enabled by configuring libtorrent with `--enable-udns`. It is now more stable than rakshasa's resolver interface.

1. The resolver callbacks are now handled by the connection manager to avoid a crash when the UDP tracker becomes invalid.
2. The UDP trackers are now optimized with a fast-path to IPV4, since the UDNS interface can only support one DNS resolution method a time. This significantly reduces the amount of CPU instructions required to update a UDP tracker and avoids redundant network sockets.

## Version 5.4 Release Notes
This release includes two hash threads instead of one to better split the load between multiple threads. For instance, instead of 30% on a single thread it will execute two threads with 15%. Half the downloads are assigned to one thread and the other half to the other thread.

## Summary of important changes
* https://github.com/stickz/rtorrent/pull/38
* https://github.com/stickz/rtorrent/pull/39
* https://github.com/stickz/rtorrent/pull/40
* https://github.com/stickz/rtorrent/pull/41
* https://github.com/stickz/rtorrent/pull/42
* https://github.com/stickz/rtorrent/pull/28
* https://github.com/stickz/rtorrent/pull/29
* https://github.com/stickz/rtorrent/pull/32
* https://github.com/stickz/rtorrent/pull/33