### PR TITLE
rTorrent: Upgrade to v6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ARG RUTORRENT_VERSION=12eb2cfba5846714cc9909865ceba3a7c1db0de7
 ARG GEOIP2_RUTORRENT_VERSION=4ff2bde530bb8eef13af84e4413cedea97eda148
 ARG DUMP_TORRENT_VERSION=302ac444a20442edb4aeabef65b264a85ab88ce9
 
-# v6.1-0.9.8-0.13.8
-ARG RTORRENT_STICKZ_VERSION=7e852c88465682864ef80d86f1d085d932ef3d89
+# v6.2-0.9.8-0.13.8
+ARG RTORRENT_STICKZ_VERSION=0165b4b6dde384d30c2b41ae6d6a2cd23b55c71e
 
 ARG ALPINE_VERSION=3.19
 ARG ALPINE_S6_VERSION=${ALPINE_VERSION}-2.2.0.3
@@ -216,7 +216,6 @@ RUN apk --update --no-cache add \
     brotli \
     ca-certificates \
     coreutils \
-    cppunit-dev \
     dhclient \
     ffmpeg \
     findutils \


### PR DESCRIPTION
## Version 6.2 Release
This release contains a few minor bug fixes and performance changes.

## What's Changed
* Fix compile with GCC 14 by @stickz in https://github.com/stickz/rtorrent/commit/52693ae5788a41e046b77d55afd0f40a8fea3414
* Drop CPPUNIT dependency by @stickz in https://github.com/stickz/rtorrent/commit/6f7bdfd9a916caa1da19845e99ee5c4fc6af5922
* Only write piece timestamp when required by @stickz in https://github.com/stickz/rtorrent/commit/f671ae97e54f38ae91c20c668ffe581e60abb46b
* Fix Handshake read buffer size by @stickz in https://github.com/stickz/rtorrent/commit/faede8af61804bad1d89ba9654ced467ec4f7328
* Fix memory access compile warning by @stickz in https://github.com/stickz/rtorrent/commit/33495c44a8354c35877b5139c1ffa8e64193ed5e

**Full Changelog**: https://github.com/stickz/rtorrent/compare/v6.1-0.9.8-0.13.8...v6.2-0.9.8-0.13.8