### PR TITLE
rTorrent: Switch to rakshasa v0.15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ARG RUTORRENT_VERSION=cc07f10d62e9348fdc3438a17939155c581e4dfe
 ARG GEOIP2_RUTORRENT_VERSION=4ff2bde530bb8eef13af84e4413cedea97eda148
 ARG DUMP_TORRENT_VERSION=302ac444a20442edb4aeabef65b264a85ab88ce9
 
-# rtorrent and libtorrent version 0.15.3
+# libtorrent v0.15.3
 ARG LIBTORRENT_VERSION=0cb559ea23fa67ded8aea69c93cba50ae0ab243f
+# rtorrent v0.15.3
 ARG RTORRENT_VERSION=6f8c1246dc013d1d5c39ecd66373346ac42fe746
 
 ARG ALPINE_VERSION=3.21
@@ -148,7 +149,7 @@ RUN tree ${DIST_PATH}
 
 WORKDIR /usr/local/src/mktorrent
 COPY --from=src-mktorrent /src .
-RUN echo "CC = gcc" >> Makefile	
+RUN echo "CC = gcc" >> Makefile
 RUN echo "CFLAGS = -w -flto -O3" >> Makefile
 RUN echo "USE_PTHREADS = 1" >> Makefile
 RUN echo "USE_OPENSSL = 1" >> Makefile
@@ -199,7 +200,7 @@ RUN echo "net.core.rmem_max = 67108864" >> /etc/sysctl.conf \
 RUN echo "@314 http://dl-cdn.alpinelinux.org/alpine/v3.14/main" >> /etc/apk/repositories \
   && echo "@320 http://dl-cdn.alpinelinux.org/alpine/v3.20/main" >> /etc/apk/repositories \
   && apk --update --no-cache add unrar@314 dhclient@320
-  
+
 RUN apk --update --no-cache add \
     apache2-utils \
     bash \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## About
 
-[stickz rTorrent](https://github.com/stickz/rtorrent) with [ruTorrent](https://github.com/Novik/ruTorrent)
+[rTorrent](https://github.com/rakshasa/rtorrent) with [ruTorrent](https://github.com/Novik/ruTorrent)
 Docker image.
 
 > [!TIP] 
@@ -53,9 +53,7 @@ ___
 
 * Run as non-root user
 * Multi-platform image
-* Latest rTorrent and libTorrent from [rTorrent stickz](https://github.com/stickz/rtorrent) project.
-  * Includes significant performance and stability improvements.
-  * Includes compatibility with Link Time Optimizations.
+* Latest [rTorrent](https://github.com/rakshasa/rtorrent) / [libTorrent](https://github.com/rakshasa/libtorrent) release compiled from source
 * Latest [ruTorrent](https://github.com/Novik/ruTorrent) release
 * Domain name resolving enhancements with [c-ares](https://github.com/rakshasa/rtorrent/wiki/Performance-Tuning#rtrorrent-with-c-ares) and [UDNS](https://www.corpit.ru/mjt/udns.html) for asynchronous DNS requests
 * Enhanced [rTorrent config](rootfs/tpls/.rtorrent.rc) and bootstraping with a [local config](rootfs/tpls/etc/rtorrent/.rtlocal.rc)


### PR DESCRIPTION
Support for rTorrent rakshasa has resumed. rTorrent stickz is being deprecated in favour of this new stable rakshasa release. It has tinyxml2 and UDNS bundled with the software. Requires #438 . closes #431 .

https://github.com/rakshasa/rtorrent/releases/tag/v0.15.3

The purpose of rtorrent stickz was due to dropped support of rtorrent rakshasa. It contained UDNS for stability purposes. Now that rakshasa has resumed support, bundled UDNS and made a stable release, there is no reason left to maintain rtorrent stickz.