### PR TITLE
Upgrade to c-ares & curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
 ARG LIBSIG_VERSION=3.0.3
-ARG CARES_VERSION=1.34.4
-ARG CURL_VERSION=8.11.1
+ARG CARES_VERSION=1.34.5
+ARG CURL_VERSION=8.12.1
 ARG MKTORRENT_VERSION=v1.1
 ARG GEOIP2_PHPEXT_VERSION=1.3.1
 
@@ -89,6 +89,7 @@ RUN apk --update --no-cache add \
     cmake \
     gd-dev \
     geoip-dev \
+    libpsl-dev \
     libtool \
     libxslt-dev \
     linux-headers \


### PR DESCRIPTION
1. Upgrades c-ares from `1.34.4` to `1.34.5` for bug fixes. 
2. Upgrades cURL from `8.11.1` to `8.12.1`. The next minor release with bug fixes for c-ares.
3. Add new libpsl-dev requirement for cURL.