### PR TITLE
Add a 10 seconds delay before executing initplugins.php

### DIFF
--- a/rootfs/tpls/etc/rtorrent/.rtlocal.rc
+++ b/rootfs/tpls/etc/rtorrent/.rtlocal.rc
@@ -67,5 +67,5 @@ log.add_output = "rpc_events","log"
 #log.execute = (cat,(cfg.logs),"execute.log")
 #log.xmlrpc = (cat,(cfg.logs),"xmlrpc.log")
 
-# Initialize plugins
-execute2 = {sh,-c,/usr/bin/php84 /var/www/rutorrent/php/initplugins.php rtorrent &}
+# Initialize plugins after a 10 seconds delay
+schedule2 = init_plugins, 10, 0, "execute2 = {sh,-c,/usr/bin/php84 /var/www/rutorrent/php/initplugins.php rtorrent &}"


### PR DESCRIPTION
fixes #247 

Very often ruTorrent plugins are not initialized. 
For some time I used crontab to run initplugin.php periodically, but after some research I found this comment explaining how to add a delay at startup: https://github.com/rakshasa/rtorrent/issues/1046#issuecomment-812257989
I added the line in my .rtorrent.rc and it seems to work, but I think it need to be in .rtlocal.rc