### PR TITLE
Fix PHP PATH_INFO support for ruTorrent filemanager-media plugin

### DIFF
--- a/rootfs/tpls/etc/nginx/conf.d/rutorrent.conf
+++ b/rootfs/tpls/etc/nginx/conf.d/rutorrent.conf
@@ -15,7 +15,7 @@ server {
         try_files $uri $uri/ =404;
     }
 
-    location ~ \.php$ {
+    location ~ \.php($|/) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         set $path_info $fastcgi_path_info;
         try_files $fastcgi_script_name =404;


### PR DESCRIPTION
This PR updates the Nginx PHP location block to properly support
PATH_INFO-style routes.

Previously, the configuration only matched URLs ending exactly in
`.php`:

    location ~ \.php$

As a result, requests such as:

    /plugin.php/path/to/resource

returned 404 errors because they did not match the PHP location block.

The configuration has been updated to:

    location ~ \.php($|/)

which allows additional path segments after `.php` and correctly
passes them to PHP via `PATH_INFO`.

This change is required for the ruTorrent `filemanager-media`
plugin, which relies on this routing style to stream and browse
files directly from the web interface.