### PR TITLE
Fix: Force s6 to use SIGINT for rTorrent graceful shutdown

### DIFF
--- a/rootfs/etc/cont-init.d/04-create-services.sh
+++ b/rootfs/etc/cont-init.d/04-create-services.sh
@@ -20,6 +20,7 @@ EOL
 chmod +x /etc/services.d/php-fpm/run
 
 mkdir -p /etc/services.d/rtorrent
+echo 2 > /etc/services.d/rtorrent/down-signal
 cat > /etc/services.d/rtorrent/run <<EOL
 #!/usr/bin/execlineb -P
 with-contenv


### PR DESCRIPTION
### The Issue
When the container is stopped or restarted, rTorrent leaves "ghosted" sessions on private trackers. The trackers never receive the event=stopped signal, resulting in inflated active torrent counts.

### The Cause
By default the s6 supervisor sends SIGTERM (15) during shutdown. However, rTorrent is hardcoded to treat SIGTERM as an emergency "fast shutdown" - it saves state to disk but intentionally skips contacting trackers. A normal graceful shutdown in rTorrent requires SIGINT (2).

### The Fix
This PR creates the down-signal file inside /etc/services.d/rtorrent during the 04-create-services initialization. By echoing 2 into this file, s6 is instructed to send SIGINT instead of SIGTERM. This forces rTorrent to execute its standard shutdown routine, allowing it to successfully deregister all active sessions from trackers before exiting, provided the user has configured an adequate stop_grace_period.

### Notes
This fixes the problem for me. We can also make it opt in via env variable, but imo it's expected behavior that it does not kill it with hammer without contacting trackers.

Somewhat related to this comment:
https://github.com/crazy-max/docker-rtorrent-rutorrent/issues/311#issuecomment-1876719427